### PR TITLE
Create new Timestamp parameter on every request

### DIFF
--- a/lib/amazon_pay/client.rb
+++ b/lib/amazon_pay/client.rb
@@ -92,7 +92,6 @@ module AmazonPay
         'AWSAccessKeyId' => @access_key,
         'SignatureMethod' => 'HmacSHA256',
         'SignatureVersion' => '2',
-        'Timestamp' => Time.now.utc.iso8601,
         'Version' => AmazonPay::API_VERSION
       }
 

--- a/lib/amazon_pay/request.rb
+++ b/lib/amazon_pay/request.rb
@@ -68,6 +68,7 @@ module AmazonPay
     # the post url.
     def build_post_url
       @optional.map { |k, v| @parameters[k] = v unless v.nil? }
+      @parameters['Timestamp'] = Time.now.utc.iso8601 unless @parameters.has_key?('Timestamp')
       @parameters = @default_hash.merge(@parameters)
       post_url = @parameters.sort.map { |k, v| "#{k}=#{custom_escape(v)}" }.join('&')
       post_body = ['POST', @mws_endpoint.to_s, "/#{@sandbox_str}/#{AmazonPay::API_VERSION}", post_url].join("\n")

--- a/test/amazon_pay_unit_test.rb
+++ b/test/amazon_pay_unit_test.rb
@@ -25,7 +25,6 @@ class AmazonPayUnitTest < Minitest::Test
     'AWSAccessKeyId' => ACCESS_KEY,
     'SignatureMethod' => 'HmacSHA256',
     'SignatureVersion' => '2',
-    'Timestamp' => Time.now.utc.iso8601,
     'Version' => AmazonPay::API_VERSION
   }
 


### PR DESCRIPTION
This addresses the following issue: https://github.com/amzn/amazon-pay-sdk-ruby/issues/14