### PR TITLE
Fix typo. "client.client.get_merchant_account_status"

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ client = AmazonPay::Client.new(
   secret_key
 )
 
-response = client.client.get_merchant_account_status
+response = client.get_merchant_account_status
 
 ```
 


### PR DESCRIPTION
Description of changes:

I found a typo
`response = client.client.get_merchant_account_status`
in README.

I corrected the typos like this.
`response = client.get_merchant_account_status`

thank you.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
