### PR TITLE
implement generate_button_signature

### DIFF
--- a/lib/amazon_pay/client.rb
+++ b/lib/amazon_pay/client.rb
@@ -15,6 +15,8 @@ module AmazonPay
       :merchant_id,
       :access_key,
       :secret_key,
+      :private_key,
+      :public_key_id,
       :sandbox,
       :currency_code,
       :region,
@@ -57,6 +59,8 @@ module AmazonPay
       merchant_id,
       access_key,
       secret_key,
+      private_key: nil,
+      public_key_id: nil,
       sandbox: false,
       currency_code: :usd,
       region: :na,
@@ -75,6 +79,8 @@ module AmazonPay
       @merchant_id = merchant_id
       @access_key = access_key
       @secret_key = secret_key
+      @private_key = private_key
+      @public_key_id = public_key_id
       @currency_code = currency_code.to_s.upcase
       @sandbox = sandbox
       @sandbox_str = @sandbox ? 'OffAmazonPayments_Sandbox' : 'OffAmazonPayments'
@@ -1134,6 +1140,11 @@ module AmazonPay
       end
 
       list
+    end
+
+    def generate_button_signature(payload)
+      hex = hash_and_hex payload.to_json
+      sign_payload hex, @private_key
     end
 
     def operation(parameters, optional)

--- a/lib/amazon_pay/version.rb
+++ b/lib/amazon_pay/version.rb
@@ -1,5 +1,5 @@
 module AmazonPay
-  VERSION = '2.6.1'.freeze
+  VERSION = '2.7.0'.freeze
   SDK_NAME = 'amazon-pay-sdk-ruby'.freeze
   API_VERSION = '2013-01-01'.freeze
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,6 +8,8 @@ WebMock.enable!
 require "test/unit/assertions"
 include Test::Unit::Assertions
 
+require 'openssl'
+
 require 'amazon_pay'
 
 require 'minitest/autorun'


### PR DESCRIPTION
Issue #23, if available:

Description of changes:
* add ability to `generate_button_signature`
* added test for signing and verifying payloads
* bump version number to 2.7.0

```
╰─❯ ruby test/amazon_pay_unit_test.rb
Run options: --seed 26325

# Running:

.........................................................

Finished in 30.142264s, 1.8910 runs/s, 2.6873 assertions/s.
57 runs, 81 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /Users/jurobn/code/amazon-pay-sdk-ruby/coverage. 0 / 0 LOC (100.0%) covered.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
