### PR TITLE
Fix ruby 2.7 deprecation warning in login.rb

### DIFF
--- a/lib/amazon_pay/login.rb
+++ b/lib/amazon_pay/login.rb
@@ -32,7 +32,7 @@ module AmazonPay
     # return the user's profile information.
     # @param access_token [String]
     def get_login_profile(access_token)
-      decoded_access_token = URI.decode(access_token)
+      decoded_access_token = URI::DEFAULT_PARSER.unescape(access_token)
       uri = URI("https://#{@sandbox_str}.#{@endpoint}/auth/o2/tokeninfo")
       req = Net::HTTP::Get.new(uri.request_uri)
       req['x-amz-access-token'] = decoded_access_token


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Replace deprecated `URI#unescape` method call with call on `URI::DEFAULT_PARSER#unescape`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
