### PR TITLE
URI.decode deprecated in Ruby 3

### DIFF
--- a/amazon_pay.gemspec
+++ b/amazon_pay.gemspec
@@ -24,4 +24,6 @@ Gem::Specification.new do |s|
   s.files = Dir.glob('lib/**/*') + %w(LICENSE NOTICE README.md)
   s.require_path = ['lib']
   s.license = 'Apache License, Version 2.0'
+
+  s.add_runtime_dependency 'rexml'
 end

--- a/lib/amazon_pay/login.rb
+++ b/lib/amazon_pay/login.rb
@@ -32,7 +32,7 @@ module AmazonPay
     # return the user's profile information.
     # @param access_token [String]
     def get_login_profile(access_token)
-      decoded_access_token = URI.decode(access_token)
+      decoded_access_token = CGI.unescape(access_token)
       uri = URI("https://#{@sandbox_str}.#{@endpoint}/auth/o2/tokeninfo")
       req = Net::HTTP::Get.new(uri.request_uri)
       req['x-amz-access-token'] = decoded_access_token


### PR DESCRIPTION
Issue #, if available:

Description of changes: URI.decode is obsolete in Ruby 3, and needs to be fixed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
